### PR TITLE
Fix IMDB search for a single item

### DIFF
--- a/Ember Media Manager/App.config
+++ b/Ember Media Manager/App.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-    <startup>
-        <supportedRuntime version="v2.0.50727" />
-    </startup>
+  <system.net>
+    <settings>
+      <httpWebRequest useUnsafeHeaderParsing="true"/>
+    </settings>
+  </system.net>
 </configuration>

--- a/EmberAPI/clsAPIHTTP.vb
+++ b/EmberAPI/clsAPIHTTP.vb
@@ -95,6 +95,7 @@ Public Class HTTP
             Me.wrRequest = DirectCast(WebRequest.Create(URL), HttpWebRequest)
             Me.wrRequest.Timeout = 20000
             Me.wrRequest.Headers.Add("Accept-Encoding", "gzip,deflate")
+            Me.wrRequest.KeepAlive = False
 
             If Not String.IsNullOrEmpty(Master.eSettings.ProxyURI) AndAlso Master.eSettings.ProxyPort >= 0 Then
                 Dim wProxy As New WebProxy(Master.eSettings.ProxyURI, Master.eSettings.ProxyPort)


### PR DESCRIPTION
If the IMDB search matches a single item it redirects to the movie page.
However, it seems to have trouble parsing the response and throws an exception.

WebException
{"The server committed a protocol violation. Section=ResponseStatusLine"}

Disable Keep-Alive so that the redirect uses it's own tcp connection and
relax the parser to handle malformed responses.
